### PR TITLE
Nested buckets for zones and records

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hectodns/hectodns
 go 1.12
 
 require (
+	github.com/google/gofuzz v1.0.0
 	github.com/hashicorp/hcl/v2 v2.7.0
 	github.com/miekg/dns v1.1.35
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/graphql-go/graphql v0.7.8 h1:769CR/2JNAhLG9+aa8pfLkKdR0H+r5lsQqling5WwpU=
 github.com/graphql-go/graphql v0.7.8/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=

--- a/ns/localdb/localdb_test.go
+++ b/ns/localdb/localdb_test.go
@@ -1,0 +1,85 @@
+package localdb
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/gofuzz"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hectodns/hectodns/ns"
+)
+
+func newStorage(t *testing.T) (s *Storage, path string) {
+	dbfile, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+	require.NoError(t, dbfile.Close())
+
+	s, err = NewStorage(dbfile.Name())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	return s, dbfile.Name()
+}
+
+func TestNewStorage_ok(t *testing.T) {
+	s, path := newStorage(t)
+	defer os.Remove(path)
+
+	require.NoError(t, s.Close(context.TODO()))
+}
+
+func TestStorage_CreateZone_ok(t *testing.T) {
+	s, path := newStorage(t)
+	defer os.Remove(path)
+	defer s.Close(context.TODO())
+
+	f := fuzz.New().NilChance(0)
+	var zoneName string
+	f.Fuzz(&zoneName)
+
+	zoneInput := ns.ZoneInput{Name: zoneName}
+	zone, err := s.CreateZone(context.TODO(), zoneInput)
+
+	require.NoError(t, err)
+	require.NotNil(t, zone)
+
+	assert.Equal(t, zoneName, zone.Name)
+	assert.True(t, zone.CreatedAt > 0)
+	assert.True(t, zone.UpdatedAt > 0)
+
+	// TODO: query database to ensure zone is created.
+}
+
+func TestStorage_CreateRecord_ok(t *testing.T) {
+	s, path := newStorage(t)
+	defer os.Remove(path)
+	defer s.Close(context.TODO())
+
+	f := fuzz.New().NilChance(0)
+	var (
+		zoneName   string
+		recordName string
+	)
+
+	f.Fuzz(&zoneName)
+	f.Fuzz(&recordName)
+
+	zoneInput := ns.ZoneInput{Name: zoneName}
+	recordInput := ns.RecordInput{ZoneName: zoneName, Name: recordName}
+
+	_, err := s.CreateZone(context.TODO(), zoneInput)
+	require.NoError(t, err)
+
+	record, err := s.CreateRecord(context.TODO(), recordInput)
+	require.NoError(t, err)
+	require.NotNil(t, record)
+
+	assert.Equal(t, recordName, record.Name)
+	assert.Equal(t, zoneName, record.ZoneName)
+	assert.True(t, record.ID != 0, "id must be set")
+
+	// TODO: query database to ensure zone is created.
+}

--- a/ns/resource.go
+++ b/ns/resource.go
@@ -20,8 +20,8 @@ type Zone struct {
 	UpdatedAt int64  `json:"updatedAt"`
 }
 
-func NewZone(input ZoneInput) Zone {
-	return Zone{
+func NewZone(input ZoneInput) *Zone {
+	return &Zone{
 		Name:      input.Name,
 		CreatedAt: time.Now().Unix(),
 		UpdatedAt: time.Now().Unix(),
@@ -30,7 +30,7 @@ func NewZone(input ZoneInput) Zone {
 
 type RecordInput struct {
 	ZoneName string  `json:"zoneName"`
-	TTL      int     `json:"ttl"`
+	TTL      uint    `json:"ttl"`
 	Name     string  `json:"name"`
 	Class    *string `json:"class"`
 	Type     string  `json:"type"`
@@ -39,9 +39,9 @@ type RecordInput struct {
 }
 
 type Record struct {
-	ID        int64   `json:"id"`
+	ID        uint64  `json:"id"`
 	ZoneName  string  `json:"zoneName"`
-	TTL       int     `json:"ttl"`
+	TTL       uint    `json:"ttl"`
 	Name      string  `json:"name"`
 	Class     *string `json:"class"`
 	Type      string  `json:"type"`
@@ -51,8 +51,8 @@ type Record struct {
 	UpdatedAt int64   `json:"updatedAt"`
 }
 
-func NewRecord(id int64, input RecordInput) Record {
-	return Record{
+func NewRecord(id uint64, input RecordInput) *Record {
+	return &Record{
 		ID:        id,
 		ZoneName:  input.ZoneName,
 		TTL:       input.TTL,


### PR DESCRIPTION
This patch starts storing resource records within separate zone buckets.
That's it, each zone is placed within a standalone bucket.'