### PR TITLE
Enclose GraphQL operations inside transactions

### DIFF
--- a/hectodns.go
+++ b/hectodns.go
@@ -24,7 +24,7 @@ type Proc struct {
 	ctx      context.Context
 	close    ns.ShutdownFunc
 	shutdown ns.ShutdownFunc
-	namedb   nameql.Backend
+	namedb   nameql.ActiveStorage
 
 	shutdownTimeout time.Duration
 

--- a/nameql/handler.go
+++ b/nameql/handler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type Backend interface {
+type ActiveStorage interface {
 	CreateZone(ctx context.Context, input ns.ZoneInput) (*ns.Zone, error)
 	QueryZone(ctx context.Context, input struct{ Name string }) (*ns.Zone, error)
 	QueryZones(ctx context.Context) ([]ns.Zone, error)
@@ -22,6 +22,21 @@ type Backend interface {
 	}) (*ns.Record, error)
 	QueryRecords(ctx context.Context) ([]ns.Record, error)
 
+	// OpenReadTransaction creates a new read-only transaction to execute the
+	// provided operation.
+	//
+	// This method is executed before all query operations to make the result
+	// consistent. For backends without transactional support, consider simply
+	// calling a specified operation.
+	OpenReadTransaction(ctx context.Context, op func(context.Context) error) error
+
+	// OpenWriteTransaction creates a read/write tansaction to execute the
+	// provided operation.
+	//
+	// This method is executed before all mutating operations.
+	OpenWriteTransaction(ctx context.Context, op func(context.Context) error) error
+
+	// Close closes a storage.
 	Close(context.Context) error
 }
 
@@ -43,23 +58,47 @@ func (b StubBackend) QueryRecords(context.Context) ([]ns.Record, error) {
 	return nil, errors.New("not implemented")
 }
 
-func NewHandler(backend Backend) http.Handler {
+func NewHandler(activestorage ActiveStorage) http.Handler {
 	rs := activegraph.Server{}
+
+	// In case of the mutation operation, open a single write transaction for
+	// all mutations specified, so the changes are always atomic.
+	rs.AppendAroundOp(activegraph.OperationMutation, func(
+		rw activegraph.ResponseWriter, r *activegraph.Request, h activegraph.Handler,
+	) {
+		activestorage.OpenWriteTransaction(r.Context(), func(ctx context.Context) error {
+			h.Serve(rw, r.WithContext(ctx))
+			// TODO: abort transaction when operation has failed.
+			return nil
+		})
+	})
+
+	// Open a read-only transaction for query operations, some databases, like
+	// "bbolt" are required to open a read-only transaction to consistently
+	// access the data.
+	rs.AppendAroundOp(activegraph.OperationQuery, func(
+		rw activegraph.ResponseWriter, r *activegraph.Request, h activegraph.Handler,
+	) {
+		activestorage.OpenReadTransaction(r.Context(), func(ctx context.Context) error {
+			h.Serve(rw, r.WithContext(ctx))
+			return nil
+		})
+	})
 
 	rs.HandleType(activegraph.NewType(ns.ZoneInput{}, nil))
 	rs.HandleType(activegraph.NewType(ns.Zone{}, nil))
 	{
-		rs.HandleQuery("zone", backend.QueryZone)
-		rs.HandleQuery("zones", backend.QueryZones)
-		rs.HandleMutation("createZone", backend.CreateZone)
+		rs.HandleQuery("zone", activestorage.QueryZone)
+		rs.HandleQuery("zones", activestorage.QueryZones)
+		rs.HandleMutation("createZone", activestorage.CreateZone)
 	}
 
 	rs.HandleType(activegraph.NewType(ns.RecordInput{}, nil))
 	rs.HandleType(activegraph.NewType(ns.Record{}, nil))
 	{
-		rs.HandleQuery("record", backend.QueryRecord)
-		rs.HandleQuery("records", backend.QueryRecords)
-		rs.HandleMutation("createRecord", backend.CreateRecord)
+		rs.HandleQuery("record", activestorage.QueryRecord)
+		rs.HandleQuery("records", activestorage.QueryRecords)
+		rs.HandleMutation("createRecord", activestorage.CreateRecord)
 	}
 
 	return rs.HandleHTTP()


### PR DESCRIPTION
This patch encloses all GraphQL operations inside transactions:
read-only operations for queries and read/write operations for mutations.